### PR TITLE
Introduce devcontainer settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM rust:1.83.0-bookworm
+

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,10 @@
+services:
+  notectl-dev:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspaces/notectl-dev
+    working_dir: /workspaces/notectl-dev:cached
+    command: sleep infinity
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "notectl development container",
+  "dockerComposeFile": "compose.yml",
+  "service": "notectl-dev",
+  "workspaceFolder": "/workspaces/notectl-dev",
+  "remoteUser": "root"
+}


### PR DESCRIPTION
## 概要

notectlの開発環境向けに、devcontainerの設定などを追加しています。

## やったこと
- devcontainer用の設定を.devcontainer以下に追加しています。

## 動作確認方法
###  vimやemacsなどのエディタを使っている場合
[devcontainer cli](https://github.com/devcontainers/cli)をインストールしたうえで以下のコマンドをnotectlディレクトリ内で実行します。

```console
devcontainer up --workspace-folder .
```

実行後、エラーなどがなければ以下のコマンドでdevcontainerにbashで入れます。

```console
devcontainer exec --workspace-folder . bash
```

あとはdevcontainer内で `cargo build`などが実行できればOKです

### VS Codeを使っている場合

notectlのディレクトリをVS Codeで開きます。
コンテナで開きなおすか確認されるので、ディレクトリを開きなおします。

あとは環境が自動的に構築されるので、完了後にbashなどで `cargo build`が実行できればOKです。

## その他

最新のRustのバージョンを使われているようだったのでコンテナイメージは`rust:1.83.0-bookworm`を使うようにしています。
また既存のDockerfileでdebian12が指定されているようだったのでbookwormを使うようにしています。