### PR TITLE
fix(note): meilisearchからドキュメントを削除する際userHostを考慮していなかった

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -70,6 +70,21 @@ services:
       interval: 5s
       retries: 20
 
+  meilisearch:
+    restart: unless-stopped
+    image: getmeili/meilisearch:latest
+    ports:
+      - "7700:7700"
+    environment:
+      - MEILI_NO_ANALYTICS=true
+      - MEILI_ENV=production
+      - MEILI_MASTER_KEY=FN6sKuqo5nF8OTAj4kE3NDTZ
+    networks:
+      - internal_network
+      - external_network
+    volumes:
+      - ./meilisearch:/meili_data
+
 networks:
   internal_network:
     internal: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .devcontainer/redis1
 .devcontainer/redis2
 .devcontainer/nginx/certs
+.devcontainer/meilisearch

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,6 +1,6 @@
 use crate::cli::config::show::ConfigCommand;
 use crate::cli::vapid::generate;
-use clap::{Parser, Subcommand, ColorChoice};
+use clap::{ColorChoice, Parser, Subcommand};
 
 use crate::cli::id::IdCommand;
 use crate::cli::note::NoteCommand;

--- a/src/cli/note/delete.rs
+++ b/src/cli/note/delete.rs
@@ -33,7 +33,7 @@ pub async fn delete(
     // do if meilisearch is enabled
     if let Some(meili_config) = config.meilisearch {
         // get meilisearch config
-        let host = meili_config.host;
+        let meili_host = meili_config.host;
         let port = meili_config.port;
         let ssl = meili_config.ssl;
         let api_key = meili_config.api_key;
@@ -44,7 +44,12 @@ pub async fn delete(
         let uid = format!("{}---notes", m_index);
 
         // parse meilisearch url for meilisearch_sdk
-        let url = format!("{}://{}:{}", if ssl { "https" } else { "http" }, host, port);
+        let url = format!(
+            "{}://{}:{}",
+            if ssl { "https" } else { "http" },
+            meili_host,
+            port
+        );
         // create meilisearch client
         let client = meilisearch_sdk::client::Client::new(url, Some(api_key)).unwrap();
         // createdAtをfilterの条件としてmeilisearchから削除する
@@ -58,11 +63,25 @@ pub async fn delete(
             tracing::error!("Cannot specify today or future date");
             std::process::exit(3);
         }
-        let task = DocumentDeletionQuery::new(&index)
-            .with_filter(format!("createdAt < {}", date).as_str())
-            .execute::<MeiliNotes>()
-            .await
-            .unwrap();
+        let created_at = format!("createdAt < {}", date);
+        let base_filter = created_at.clone();
+
+        let task = if let Some(host) = host {
+            let user_host = format!("userHost = \"{}\"", host);
+            let query = format!("{} AND {}", base_filter, user_host);
+            DocumentDeletionQuery::new(&index)
+                .with_filter(&query)
+                .execute::<MeiliNotes>()
+                .await
+                .unwrap()
+        } else {
+            DocumentDeletionQuery::new(&index)
+                .with_filter(&base_filter)
+                .execute::<MeiliNotes>()
+                .await
+                .unwrap()
+        };
+
         task.wait_for_completion(&client, None, None).await.unwrap();
         tracing::info!("Meilisearch delete task completed");
     } else {

--- a/src/cli/search/list.rs
+++ b/src/cli/search/list.rs
@@ -1,8 +1,8 @@
+use meilisearch_sdk::client::*;
 use syntect::easy::HighlightLines;
-use syntect::highlighting::{ThemeSet, Style};
+use syntect::highlighting::{Style, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
-use meilisearch_sdk::client::*;
 
 use crate::config::load_config;
 
@@ -18,7 +18,7 @@ pub async fn list(config_path: &str) -> Result<(), Box<dyn std::error::Error>> {
     let client: Client = Client::new(host_url, Some(api_key)).unwrap();
     let index = client.list_all_indexes_raw().await.unwrap();
     let json = serde_json::to_string_pretty(&index).unwrap();
-    
+
     let ps = SyntaxSet::load_defaults_newlines();
     let ts = ThemeSet::load_defaults();
 

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -5,9 +5,18 @@ pub fn style() -> clap::builder::Styles {
     clap::builder::Styles::styled()
         .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
         .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
-        .error(AnsiColor::Red.on_default().effects(Effects::BOLD).effects(Effects::DOUBLE_UNDERLINE))
+        .error(
+            AnsiColor::Red
+                .on_default()
+                .effects(Effects::BOLD)
+                .effects(Effects::DOUBLE_UNDERLINE),
+        )
         .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
-        .placeholder(AnsiColor::White.on_default().effects(Effects::DOUBLE_UNDERLINE))
+        .placeholder(
+            AnsiColor::White
+                .on_default()
+                .effects(Effects::DOUBLE_UNDERLINE),
+        )
         .valid(AnsiColor::Green.on_default().effects(Effects::BOLD))
         .invalid(AnsiColor::Red.on_default().effects(Effects::BOLD))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use std::{fs, path::Path};
 
+use serde::{Deserialize, Serialize};
 use syntect::easy::HighlightLines;
-use syntect::highlighting::{ThemeSet, Style};
+use syntect::highlighting::{Style, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## What
meilisearchのインデックス上のドキュメントに対して`note delete`コマンドで削除した際、誤って自鯖のノートも対象となる問題を修正

## Why
close #23 