### PR TITLE
fix: userHostをIS NOT NULLに

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
 
 ## Fix
 - opensslを0.10.70に
+- meilisearchが有効な場合に`note delete`を実行する際に、誤ってローカルの投稿が削除される問題を修正
 
 # 0.1.1
 

--- a/src/cli/note/delete.rs
+++ b/src/cli/note/delete.rs
@@ -76,7 +76,7 @@ pub async fn delete(
         .await
         .unwrap()
     } else {
-      let user_host = format!("userHost IS NULL");
+      let user_host = "userHost IS NOT NULL".to_string();
       let query = format!("{} AND {}", base_filter, user_host);
       DocumentDeletionQuery::new(&index)
         .with_filter(&query)

--- a/src/util/id/aidx.rs
+++ b/src/util/id/aidx.rs
@@ -29,7 +29,7 @@ lazy_static! {
 fn get_time(time: u64) -> String {
   let time = time as i64 - TIME2000 as i64;
   let timestamp = std::cmp::max(0, time);
-  format!("{:0>8}", radix_encode(timestamp as i64, 36))
+  format!("{:0>8}", radix_encode(timestamp, 36))
 }
 
 fn get_noise() -> String {


### PR DESCRIPTION
## What
meilisearch使用時にuserHostの条件分岐が間違っていたのを修正

## Why 
close #34 