### PR TITLE
fix: note deleteでメモリリークが起きる問題

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.1
+
+## Release Date
+Unreleased
+
+## Fix
+- `note delete`でデータ量が多い際メモリリークすることがある問題
+
 # 0.2.0
 
 ## Release Date

--- a/src/cli/note/delete.rs
+++ b/src/cli/note/delete.rs
@@ -196,6 +196,15 @@ pub async fn delete(
 
   // delete from database
   let notes = query.all(&txn).await?;
+
+  let total = notes.len();
+  if total == 0 {
+    tracing::info!("No notes to delete");
+    txn.commit().await?;
+    pg_client.close().await?;
+    return Ok(());
+  }
+
   let mut reply_ids = std::collections::HashSet::new();
   for note in &notes {
     if let Some(reply_id) = &note.reply_id {

--- a/src/cli/note/delete.rs
+++ b/src/cli/note/delete.rs
@@ -230,11 +230,8 @@ pub async fn delete(
     }
   }
 
-  let chunk_size = 100;
-  for chunk in notes.chunks(chunk_size) {
-    let futures = chunk.iter().map(|note| note.clone().delete(&txn));
-    futures::future::join_all(futures).await;
-    tracing::info!("Deleted {} notes", chunk.len());
+  for note in notes {
+    note.delete(&txn).await?;
   }
 
   // commit transaction

--- a/src/cli/note/delete.rs
+++ b/src/cli/note/delete.rs
@@ -230,5 +230,6 @@ pub async fn delete(
 
   // commit transaction
   txn.commit().await?;
+  pg_client.close().await?;
   Ok(())
 }


### PR DESCRIPTION
## What
`note delete`でメモリリークが起きる問題を修正

## Why
close #51 